### PR TITLE
fix port forwardig on zed

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,10 +2,7 @@
   "build": {
     "dockerfile": "Dockerfile"
   },
-  "forwardPorts": [
-    3000,
-    3001
-  ],
+  "appPort": [3000, 3001],
   "portsAttributes": {
     "3000": {
       "label": "Frontend"

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,7 +1,7 @@
 use axum::{Router, extract::Query, http::header, response::IntoResponse, routing::get};
 use photon::PhotonImage;
 use serde::Deserialize;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use tower_http::trace::TraceLayer;
 
 #[tokio::main]
@@ -16,8 +16,9 @@ async fn main() {
         .route("/exercise_4", get(exercise_4))
         .layer(TraceLayer::new_for_http());
 
-    // We must use 127.0.0.1 as hostname for this to work in a dev container.
-    let addr = SocketAddr::from(([127, 0, 0, 1], 3001));
+    // We must use 0.0.0.0 as hostname for this to work in a dev container.
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 3001);
+
     tracing::info!("Starting server on {}", addr);
 
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();

--- a/serve.sh
+++ b/serve.sh
@@ -25,8 +25,8 @@ if ! command -v watchexec >/dev/null 2>&1; then
   exit 1
 fi
 
-# We must use 127.0.0.1 as hostname for this to work in a dev container.
-watchexec --watch exercises --watch frontend/src -r 'wasm-pack build frontend --target no-modules --out-dir wasm --no-typescript --no-pack --dev && mdbook serve --hostname 127.0.0.1 frontend' &
+# We must use 0.0.0.0 as hostname for this to work in a dev container.
+watchexec --watch exercises --watch frontend/src -r 'wasm-pack build frontend --target no-modules --out-dir wasm --no-typescript --no-pack --dev && mdbook serve --hostname 0.0.0.0 -p 3000 frontend' &
 watchexec --watch exercises --watch backend/src -r cargo run --bin backend
 
 wait


### PR DESCRIPTION
This should not impact vscode but makes this feature work on zed (as it only implements the more basic `appPort` setting https://zed.dev/docs/dev-containers#known-limitations)