### PR TITLE
exercices 1 improvements

### DIFF
--- a/exercises/src/exercise_1.rs
+++ b/exercises/src/exercise_1.rs
@@ -7,10 +7,10 @@ use photon::PhotonImage;
 /// This workshop is divided into four exercises, each one a bit more complicated than the previous.
 /// During these exercises we will be building **image transformers** that accept an input image, apply
 /// some transformation and return an output image.
-pub fn transform(img: &PhotonImage, width: u32) -> PhotonImage {
+pub fn transform(img: &PhotonImage, target_width: u32) -> PhotonImage {
     // Calculate aspect ratio
-    let aspect_ratio = img.get_height() as f32 / img.get_width() as f32;
-    let height = (width as f32 * aspect_ratio) as u32;
+    let aspect_ratio = img.get_width() as f32 / img.get_height() as f32;
+    let _target_height = (target_width as f32 / aspect_ratio) as u32;
 
     // import and call the resize function here!
     todo!("call the resize function!")

--- a/frontend/book/exercise_1.md
+++ b/frontend/book/exercise_1.md
@@ -20,7 +20,7 @@ A **crate** is a Rust package, similar to npm packages or Python modules. Crates
 Let's implement our first transformation by editing `exercises/src/exercise_1.rs`:
 
 ```rust
-pub fn transform(img: PhotonImage, width: u32) -> PhotonImage {
+pub fn transform(img: &PhotonImage, target_width: u32) -> PhotonImage {
     todo!()
 }
 ```


### PR DESCRIPTION
Fix a typo

Update to match the new function signature.

aspect ratio is always defined as width/height, not the other way around.

Also prefix variables with `target_` so the algo is clearer.