### PR TITLE
set rust-analyzer.cargo.targetDir=true to avoid recompilation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "rust-analyzer.cargo.targetDir": true
+}


### PR DESCRIPTION
#68 doesn't solve the issue for me, so adding this as well. I don't think it hurts to try solving it in more ways than one.

As for Zed, it appears to not expose such a setting.

We could investigate if using an env var would solve it more easily (if we find the time).