### PR TITLE
refer to abort instead of crash

### DIFF
--- a/frontend/book/exercise_2.md
+++ b/frontend/book/exercise_2.md
@@ -191,7 +191,7 @@ Unlike JavaScript's `switch`, there's no fall-through and no `break` needed — 
 error[E0004]: non-exhaustive patterns: `&_` not covered
 ```
 
-This might feel strict, but it catches bugs at compile time that JavaScript would only reveal at runtime. The `panic!` macro crashes the program with an error message—similar to throwing an uncaught exception. In Exercise 4, we'll learn about Rust's `Result` type for more graceful error handling.
+This might feel strict, but it catches bugs at compile time that JavaScript would only reveal at runtime. The `panic!` macro terminates the program with an error message—similar to throwing an uncaught exception. In Exercise 4, we'll learn about Rust's `Result` type for more graceful error handling.
 
 <div class="workshop-exercise">
     <label for="imageUrl">Input image (URL)</label>

--- a/frontend/book/exercise_3.md
+++ b/frontend/book/exercise_3.md
@@ -225,7 +225,7 @@ assert!(left.get_width() > 0);
 assert!(right.get_width() > 0);
 ```
 
-The `assert!` macro checks a condition and panics if it's false. Unlike exceptions in other languages, a panic in Rust is unrecoverable in the current thread—the program crashes with an error message.
+The `assert!` macro checks a condition and panics if it's false. Unlike exceptions in other languages, a panic in Rust is unrecoverable in the current thread—the program terminates with an error message.
 
 Assertions serve two purposes:
 


### PR DESCRIPTION
Rust is all about safety, let's not scare people with crashes. :)