### PR TITLE
Fix output image size

### DIFF
--- a/frontend/book/exercise_1.md
+++ b/frontend/book/exercise_1.md
@@ -110,9 +110,9 @@ Run **`./serve.sh`** to open the frontend, start the backend and serve your exer
     <div class="workshop-output">
         <h4>Output <span id="timing-info"></span></h4>
         <div class="workshop-output--compare" style="overflow: visible;">
-            <img id="imageOutput" class="workshop-output--compare__image-one">
+            <img id="imageOutput" class="workshop-output--compare__image-one original-size">
             <div class="workshop-output--compare__mask">
-                <img id="imageInput" class="workshop-output--compare__image-two" />
+                <img id="imageInput" class="workshop-output--compare__image-two original-size" />
             </div>
             <div class="workshop-output--compare__separator">
                 {{#include includes/slider-handle.svg}}

--- a/frontend/workshop.css
+++ b/frontend/workshop.css
@@ -67,6 +67,14 @@
   border: 1px solid rgb(0 0 0 / 0.05);
 }
 
+.workshop-output--compare .original-size {
+  width: auto;
+  object-fit: unset;
+  top: 0;
+  left: 0;
+  position: absolute;
+}
+
 .workshop-output--compare__separator {
   position: absolute;
   top: 0;


### PR DESCRIPTION
This changes the image sizing for example 1 so that images are not stretched to fill the full width of the container for exercise 1 where that ends up being confusing. Images will still be fitted into the box but will appear smaller if they are smaller than the box, e.g.:

<img width="1022" height="825" alt="Bildschirmfoto 2026-02-10 um 16 42 51" src="https://github.com/user-attachments/assets/620e17b7-c989-4131-9853-299a1edbc4f1" />

<img width="888" height="768" alt="Bildschirmfoto 2026-02-10 um 16 43 01" src="https://github.com/user-attachments/assets/a1c9ba38-2bef-43a4-81dc-744562a49721" />

<img width="857" height="636" alt="Bildschirmfoto 2026-02-10 um 16 43 13" src="https://github.com/user-attachments/assets/bcbebdb6-9100-45e3-8a9e-6a887e17ba7c" />

<img width="994" height="787" alt="Bildschirmfoto 2026-02-10 um 16 43 19" src="https://github.com/user-attachments/assets/080161d7-5401-44e8-804f-b4f612cac1bc" />

closes #100