### PR TITLE
fix(ui): remove slider and update image overflow for exercise 1

### DIFF
--- a/frontend/book/exercise_1.md
+++ b/frontend/book/exercise_1.md
@@ -109,17 +109,9 @@ Run **`./serve.sh`** to open the frontend, start the backend and serve your exer
     </div>
     <div class="workshop-output">
         <h4>Output <span id="timing-info"></span></h4>
-        <div class="workshop-output--compare" style="overflow: visible;">
-            <img id="imageOutput" class="workshop-output--compare__image-one original-size">
-            <div class="workshop-output--compare__mask">
-                <img id="imageInput" class="workshop-output--compare__image-two original-size" />
-            </div>
-            <div class="workshop-output--compare__separator">
-                {{#include includes/slider-handle.svg}}
-            </div>
-            <input class="workshop-output--compare__input" type="range" min="0" step="0.5" max="100" value="50">
+        <div class="workshop-output--noncompare">
+            <img id="imageOutput" />
         </div>
-        <div class="workshop-output--compare__labels"><p>Input image</p><p>Output image</p></div>
     </div>
 </div>
 

--- a/frontend/book/exercise_1.md
+++ b/frontend/book/exercise_1.md
@@ -109,7 +109,7 @@ Run **`./serve.sh`** to open the frontend, start the backend and serve your exer
     </div>
     <div class="workshop-output">
         <h4>Output <span id="timing-info"></span></h4>
-        <div class="workshop-output--noncompare">
+        <div class="workshop-output--noncompare workshop-output--orig-size">
             <img id="imageOutput" />
         </div>
     </div>

--- a/frontend/book/exercise_4.md
+++ b/frontend/book/exercise_4.md
@@ -189,7 +189,7 @@ Consult the documentation for [rayons methods](https://docs.rs/rayon/latest/rayo
     </div>
     <div class="workshop-output">
         <h4>Output <span id="timing-info"></span></h4>
-        <div class="workshop-output--noncompare">
+        <div class="workshop-output--noncompare workshop-output--orig-size">
             <img id="imageOutput" />
         </div>
     </div>

--- a/frontend/workshop.css
+++ b/frontend/workshop.css
@@ -99,7 +99,11 @@
 }
 
 .workshop-output--noncompare {
-  overflow: hidden;
+  overflow: scroll;
+}
+
+.workshop-output--noncompare.workshop-output--orig-size img {
+  max-width: unset;
 }
 
 .workshop-output--compare__image-one {
@@ -115,10 +119,6 @@
 .workshop-output--compare__image-two {
   object-fit: contain;
   max-width: calc(var(--content-max-width) - 4em - 6px) !important;
-}
-
-.workshop-output--noncompare img {
-  max-width: none;
 }
 
 .workshop-output--compare__mask {

--- a/frontend/workshop.css
+++ b/frontend/workshop.css
@@ -1,60 +1,63 @@
 .workshop-exercise {
-    margin: 1.5em 0;
-    padding: 1em;
-    border: 1px solid var(--quote-border);
-    border-radius: 4px;
-    background: var(--quote-bg);
+  margin: 1.5em 0;
+  padding: 1em;
+  border: 1px solid var(--quote-border);
+  border-radius: 4px;
+  background: var(--quote-bg);
 }
 
-.workshop-image-url, .workshop-image-param, .workshop-select {
-    padding: 0.5em;
-    margin-bottom: 1em;
-    border: 1px solid var(--quote-border);
-    border-radius: 4px;
-    font-family: var(--mono-font);
-    font-size: 0.9em;
-    background: var(--bg);
-    color: var(--fg);
+.workshop-image-url,
+.workshop-image-param,
+.workshop-select {
+  padding: 0.5em;
+  margin-bottom: 1em;
+  border: 1px solid var(--quote-border);
+  border-radius: 4px;
+  font-family: var(--mono-font);
+  font-size: 0.9em;
+  background: var(--bg);
+  color: var(--fg);
 }
 
-.workshop-image-url, .workshop-image-param {
-    width: calc(100% - 1em);
+.workshop-image-url,
+.workshop-image-param {
+  width: calc(100% - 1em);
 }
 
 .workshop-buttons {
-    display: flex;
-    gap: 0.5em;
-    margin: 1em 0;
-    flex-wrap: wrap;
+  display: flex;
+  gap: 0.5em;
+  margin: 1em 0;
+  flex-wrap: wrap;
 }
 
 .workshop-btn {
-    display: inline-block;
-    padding: 0.5em 1em;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 0.9em;
-    text-decoration: none;
-    transition: background-color 0.2s ease;
+  display: inline-block;
+  padding: 0.5em 1em;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9em;
+  text-decoration: none;
+  transition: background-color 0.2s ease;
 }
 
 .workshop-btn-backend {
-    background-color: #3273dc;
-    color: white;
+  background-color: #3273dc;
+  color: white;
 }
 
 .workshop-btn-backend:hover {
-    background-color: #2366d1;
+  background-color: #2366d1;
 }
 
 .workshop-btn-wasm {
-    background-color: #48c774;
-    color: white;
+  background-color: #48c774;
+  color: white;
 }
 
 .workshop-btn-wasm:hover {
-    background-color: #3ec46d;
+  background-color: #3ec46d;
 }
 
 /* ----- IMAGE COMPARISON SLIDER (https://codepen.io/stanko/pen/myddXKm) ----- */
@@ -87,11 +90,16 @@
   pointer-events: none;
 }
 
-.workshop-output--compare, .workshop-output--noncompare {
+.workshop-output--compare,
+.workshop-output--noncompare {
   min-height: 30em;
   border-radius: 4px;
   background: repeating-conic-gradient(#808080 0 25%, #fff 0 50%) 50% / 20px 20px;
   border: 1px solid rgb(0 0 0 / 0.05);
+}
+
+.workshop-output--noncompare {
+  overflow: hidden;
 }
 
 .workshop-output--compare__image-one {
@@ -103,9 +111,14 @@
   display: block;
 }
 
-.workshop-output--compare__image-one, .workshop-output--compare__image-two {
+.workshop-output--compare__image-one,
+.workshop-output--compare__image-two {
   object-fit: contain;
   max-width: calc(var(--content-max-width) - 4em - 6px) !important;
+}
+
+.workshop-output--noncompare img {
+  max-width: none;
 }
 
 .workshop-output--compare__mask {
@@ -194,19 +207,19 @@
 }
 
 .workshop-output {
-    margin-top: 1em;
-    padding: 1em;
-    background: var(--bg);
-    border: 1px solid var(--quote-border);
-    border-radius: 4px;
-    text-align: center;
+  margin-top: 1em;
+  padding: 1em;
+  background: var(--bg);
+  border: 1px solid var(--quote-border);
+  border-radius: 4px;
+  text-align: center;
 }
 
 .workshop-output h4 {
-    margin-top: 0;
-    margin-bottom: 0.5em;
-    font-size: 1em;
-    color: var(--fg);
+  margin-top: 0;
+  margin-bottom: 0.5em;
+  font-size: 1em;
+  color: var(--fg);
 }
 
 label {
@@ -224,41 +237,41 @@ label {
 
 /* Comparison table styling */
 .workshop-comparison {
-    width: 100%;
-    border-collapse: collapse;
-    margin: 1em 0;
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1em 0;
 }
 
 .workshop-comparison th,
 .workshop-comparison td {
-    padding: 0.75em;
-    text-align: left;
-    border: 1px solid var(--quote-border);
+  padding: 0.75em;
+  text-align: left;
+  border: 1px solid var(--quote-border);
 }
 
 .workshop-comparison th {
-    background: var(--quote-bg);
-    font-weight: bold;
+  background: var(--quote-bg);
+  font-weight: bold;
 }
 
 .workshop-comparison tr:nth-child(even) {
-    background: var(--quote-bg);
+  background: var(--quote-bg);
 }
 
 /* Learning objectives list */
 .workshop-objectives {
-    background: var(--quote-bg);
-    padding: 1em;
-    border-radius: 4px;
-    margin: 1em 0;
+  background: var(--quote-bg);
+  padding: 1em;
+  border-radius: 4px;
+  margin: 1em 0;
 }
 
 .workshop-objectives h3 {
-    margin-top: 0;
+  margin-top: 0;
 }
 
 .workshop-objectives ul {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 #error-flash {


### PR DESCRIPTION
**Description** : This PR implements the UI improvements requested for Exercise 1.

**Changes made:**

Removed the before/after comparison slider, as Exercise 1 only needs the output image.

Removed max-width: 100% from the output image so large widths are accurately represented.

Added overflow: hidden to the image container to ensure large images don't break the layout boundaries.

Fixes #108 > Screenshots

<img width="535" height="512" alt="image" src="https://github.com/user-attachments/assets/bced06a8-b8c0-4ce5-ae6a-8d1ce3c32490" />

<img width="521" height="869" alt="image" src="https://github.com/user-attachments/assets/143ab69b-d85f-4e29-8c2b-90eff4c14f21" />
