### PR TITLE
Improve `serve.sh`

### DIFF
--- a/serve.sh
+++ b/serve.sh
@@ -26,8 +26,4 @@ if ! command -v watchexec >/dev/null 2>&1; then
 fi
 
 # We must bind to 0.0.0.0 for this to work in a dev container.
-watchexec --watch exercises --watch frontend/src -r 'wasm-pack build frontend --target no-modules --out-dir wasm --no-typescript --no-pack --dev && mdbook serve --hostname 0.0.0.0 -p 3000 frontend' &
-
-watchexec --watch exercises --watch  backend/src -r 'cargo run --target-dir target-serve --bin backend'
-
-wait
+watchexec -r 'mdbook serve --hostname 0.0.0.0 -p 3000 frontend & cargo build && wasm-pack build frontend --target no-modules --out-dir wasm --no-typescript --no-pack --dev && cargo run --bin backend & wait'

--- a/serve.sh
+++ b/serve.sh
@@ -25,5 +25,10 @@ if ! command -v watchexec >/dev/null 2>&1; then
   exit 1
 fi
 
+mdbook serve --hostname 0.0.0.0 -p 3000 frontend &
+
+# Ensure that SIGINT is forwarded to mdbook, else it keeps running.
+trap "kill $!" INT TERM
+
 # We must bind to 0.0.0.0 for this to work in a dev container.
-watchexec -r 'mdbook serve --hostname 0.0.0.0 -p 3000 frontend & cargo build && wasm-pack build frontend --target no-modules --out-dir wasm --no-typescript --no-pack --dev && cargo run --bin backend & wait'
+watchexec -r 'cargo build && wasm-pack build frontend --target no-modules --out-dir wasm --no-typescript --no-pack --dev && cargo run --bin backend'


### PR DESCRIPTION
I changed `serve.sh` around a bit:
- Moved `mdbook` out of the watchexec. This ensures `mdbook` continues to serve. `mdbook` will still see that a new wasm file is built and will reload itself.
- Initially do a `cargo build` in watchexec. If there are any compile errors, it shows them only once.
- Then do the normal wasm-pack, which will do a wasm build (and trigger a reload of `mdbook`).
- Then just run the backend.