### PR TITLE
fix(ui): align comparison slider images

### DIFF
--- a/exercises/src/exercise_2.rs
+++ b/exercises/src/exercise_2.rs
@@ -4,6 +4,4 @@ use photon::PhotonImage;
 pub fn transform(_img: &mut PhotonImage, _filter: &str) {
     // use the `match` statement to call the right transformation function depending on the argument.
     todo!()
-    
 }
-

--- a/exercises/src/exercise_2.rs
+++ b/exercises/src/exercise_2.rs
@@ -4,4 +4,6 @@ use photon::PhotonImage;
 pub fn transform(_img: &mut PhotonImage, _filter: &str) {
     // use the `match` statement to call the right transformation function depending on the argument.
     todo!()
+    
 }
+

--- a/frontend/book/exercise_2.md
+++ b/frontend/book/exercise_2.md
@@ -218,9 +218,9 @@ This might feel strict, but it catches bugs at compile time that JavaScript woul
     <div class="workshop-output">
         <h4>Output <span id="timing-info"></span></h4>
         <div class="workshop-output--compare" style="overflow: visible;">
-            <img id="imageOutput" class="workshop-output--compare__image-one">
+            <img id="imageOutput" class="workshop-output--compare__image-one original-size" style="left: auto; right: 0;">
             <div class="workshop-output--compare__mask">
-                <img id="imageInput" class="workshop-output--compare__image-two" />
+                <img id="imageInput" class="workshop-output--compare__image-two original-size" />
             </div>
             <div class="workshop-output--compare__separator">
                 {{#include includes/slider-handle.svg}}


### PR DESCRIPTION
The input image and output canvas were scaling differently due to browser defaults, causing a mismatch in the Exercise 2 slider.

Fixes #111

Screenshot
<img width="772" height="817" alt="image" src="https://github.com/user-attachments/assets/8f740787-c882-4289-b9a8-8af88e65a4e7" />
